### PR TITLE
Update api.php

### DIFF
--- a/catalog/controller/custom/api.php
+++ b/catalog/controller/custom/api.php
@@ -18,7 +18,7 @@ class Controllercustomapi extends Controller
         'data' => [],
         'meta' => []
     ];
-    private string $dbPrefix = DB_PREFIX;
+    private $dbPrefix = DB_PREFIX;
     public function __construct($registry)
     {
         parent::__construct($registry);


### PR DESCRIPTION
Mevcut hatadan kaynaklanan düzenleme. Bazı PHP versionlarında bu string tanımlamasını kabul etmiyor ve patlıyor.